### PR TITLE
Fix navigation issue and email address

### DIFF
--- a/cfp.html
+++ b/cfp.html
@@ -44,7 +44,7 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <a class="navbar-brand" href="#page-top">#FinagleCon 2015</a>
+                <a class="navbar-brand" href="index.html#page-top">#FinagleCon 2015</a>
             </div>
 
             <!-- Collect the nav links, forms, and other content for toggling -->
@@ -102,7 +102,8 @@
                 <div class="col-md-4">
                     <h3>Suggested Topics</h3>
                     <p>Real world Finagle deployments</p>
-					<p>Finagle and Java / Mux</p>
+					<p>Finagle and Mux</p>
+					<p>Finagle and Java</p>
                     <p>Testing and benchmarking Finagle applications</p>
 					<p>Writing Finagle protocols</p>
 					<p>Finagle frameworks like Finatra and Finch</p>
@@ -113,7 +114,7 @@
                     <p>CFP Open: June 5, 2015</p>
 					<p>CFP Close: June 30, 2015</p>
 					<p>CFP Notifications: July 10, 2015</p>
-					<p>Schedule Announced: July 14, 2015</p>
+					<p>Schedule Announced: July 13, 2015</p>
 					<p>Event Date: August 13, 2015</p>
                 </div>
                 <div class="col-md-4">

--- a/cfp.html
+++ b/cfp.html
@@ -57,13 +57,13 @@
                         <a href="cfp.html">CFP</a>
                     </li>
                     <li class="page-scroll">
-                        <a href="#schedule">Schedule</a>
+                        <a href="index.html#schedule">Schedule</a>
                     </li>
                     <li class="page-scroll">
-                        <a href="#sponsorship">Sponsorship</a>
+                        <a href="index.html#sponsorship">Sponsorship</a>
                     </li>
                     <li class="page-scroll">
-                        <a href="#codeofconduct">Code of Conduct</a>
+                        <a href="index.html#codeofconduct">Code of Conduct</a>
                     </li>
                    <li class="page-scroll">
                         <a href="mailto:finaglecon@twitter.com">Contact</a>

--- a/index.html
+++ b/index.html
@@ -57,13 +57,13 @@
                         <a href="cfp.html">CFP</a>
                     </li>
                     <li class="page-scroll">
-                        <a href="#schedule">Schedule</a>
+                        <a href="index.html#schedule">Schedule</a>
                     </li>
                     <li class="page-scroll">
-                        <a href="#sponsorship">Sponsorship</a>
+                        <a href="index.html#sponsorship">Sponsorship</a>
                     </li>
                     <li class="page-scroll">
-                        <a href="#codeofconduct">Code of Conduct</a>
+                        <a href="index.html#codeofconduct">Code of Conduct</a>
                     </li>
                    <li class="page-scroll">
                         <a href="mailto:finaglecon@twitter.com">Contact</a>
@@ -134,7 +134,7 @@
                     <h2>Code of Conduct</h2>
                     <hr class="star-primary">
 					<div class="col-lg-8 col-lg-offset-2 text-center">
-	                    <p>FinagleCon is intended for professional networking and collaboration within the Finagle community. Attendees are expected to behave according to professional standards and in accordance with their employer's policies on appropriate workplace behavior. Our conference is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, or religion (or lack thereof). We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks, workshops, parties, Twitter and other online media. Conference participants violating these rules may be sanctioned or expelled from the conference without a refund at the discretion of the conference organizers. Participants asked to stop any harassing behavior are expected to comply immediately. Please bring any concerns to to the immediate attention of the FinagleCon event staff, or contact <a href="mailto:travisb@twitter.com">Travis Brown</a>, FinagleCon Program Chair</p>
+	                    <p>FinagleCon is intended for professional networking and collaboration within the Finagle community. Attendees are expected to behave according to professional standards and in accordance with their employer's policies on appropriate workplace behavior. Our conference is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, or religion (or lack thereof). We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks, workshops, parties, Twitter and other online media. Conference participants violating these rules may be sanctioned or expelled from the conference without a refund at the discretion of the conference organizers. Participants asked to stop any harassing behavior are expected to comply immediately. Please bring any concerns to to the immediate attention of the FinagleCon event staff, or contact <a href="mailto:tbrown@twitter.com">Travis Brown</a>, FinagleCon Program Chair.</p>
 	                </div>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <a class="navbar-brand" href="#page-top">#FinagleCon 2015</a>
+                <a class="navbar-brand" href="index.html#page-top">#FinagleCon 2015</a>
             </div>
 
             <!-- Collect the nav links, forms, and other content for toggling -->


### PR DESCRIPTION
Currently once you've clicked through to the CFP you're stuck on the CFP page, since the other links in the header tab are only fragment identifiers. I've also corrected my email address.
