### PR TITLE
Add new sections and Google Analytics

### DIFF
--- a/cfp.html
+++ b/cfp.html
@@ -30,6 +30,16 @@
         <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
 
+    <!-- Google Analytics Magic -->
+    <script type="text/javascript">
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-39101739-6', 'finagle.github.io');
+      ga('send', 'pageview');
+    </script>
 </head>
 
 <body id="page-top" class="index">
@@ -56,6 +66,9 @@
                     </li>
                     <li class="page-scroll">
                         <a href="cfp.html">CFP</a>
+                    </li>
+                    <li class="page-scroll">
+                        <a href="index.html#sbtb">SBTB</a>
                     </li>
                     <li class="page-scroll">
                         <a href="index.html#schedule">Schedule</a>

--- a/index.html
+++ b/index.html
@@ -30,6 +30,16 @@
         <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
 
+    <!-- Google Analytics Magic -->
+    <script type="text/javascript">
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-39101739-6', 'finagle.github.io');
+      ga('send', 'pageview');
+    </script>
 </head>
 
 <body id="page-top" class="index">
@@ -58,6 +68,9 @@
                         <a href="cfp.html">CFP</a>
                     </li>
                     <li class="page-scroll">
+                        <a href="index.html#sbtb">SBTB</a>
+                    </li>
+                    <li class="page-scroll">
                         <a href="index.html#schedule">Schedule</a>
                     </li>
                     <li class="page-scroll">
@@ -81,13 +94,12 @@
         <div class="container">
             <div class="row">
                 <div class="col-lg-12">
-                    <img class="img-responsive" src="img/profile.png" alt="">
+                    <img class="img-responsive" src="img/profile.png" alt="Finagle logo">
                     <div class="intro-text">
                         <span class="name">#FinagleCon 2015</span>
                         <span class="skills">August 13th, 2015</span>
                         <hr class="star-light">
-                        <div><span class="skills">The first annual Finagle community conference</span></div>
-                        <div><span class="skills">Co-located with <a href="http://scala.bythebay.io/">Scala by the Bay 2015</a></span></div>
+                        <span class="skills">The first annual Finagle community conference</span>
                         <br />
 						<a href="https://www.regonline.com/Register/Checkin.aspx?EventID=1719477" class="btn btn-lg btn-outline">
 	                        <i class="fa fa-user"> Register</i>
@@ -98,28 +110,49 @@
         </div>
     </header>
 
-    <!-- Contact Section -->
-    <section id="schedule">
+    <!-- Scala by the Bay Section -->
+    <section id="sbtb">
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-12 text-center">
+                    <h2>Scala by the Bay</h2>
+                    <hr class="star-primary">
+                    <div class="col-lg-8 col-lg-offset-2 text-center">
+                        <p>FinagleCon is co-located with <a href="http://scala.bythebay.io/">Scala by the Bay 2015</a>,
+                            and Scala by the Bay attendees will receive a discount code providing free registration for FinagleCon.
+                        </p>
+                        <br />
+                        <a href="http://scala.bythebay.io/tickets.html" class="btn btn-lg btn-success">
+                            <i class="fa fa-user"> Register for Scala by the Bay</i>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Schedule Section -->
+    <section class="success" id="schedule">
         <div class="container">
             <div class="row">
                 <div class="col-lg-12 text-center">
                     <h2>Schedule</h2>
-                    <hr class="star-primary">
+                    <hr class="star-light">
                     <div class="col-lg-8 col-lg-offset-2 text-center">
-	                    <p>The schedule will be posted when the program is announced on July 13th</p>
+	                    <p>The schedule will be posted when the program is announced on July 13th.</p>
 	                </div>
                 </div>
             </div>
         </div>
     </section>
 
-   <!-- CFP Section -->
-    <section class="success" id="sponsorship">
+   <!-- Sponsorship Section -->
+    <section id="sponsorship">
         <div class="container">
             <div class="row">
                 <div class="col-lg-12 text-center">
                     <h2>Sponsorship</h2>
-                    <hr class="star-light">
+                    <hr class="star-primary">
 					<div class="col-lg-8 col-lg-offset-2 text-center">
 	                    <p>If you're interested in sponsoring, please see the <a href="sponsorship/prospectus.pdf">prospectus</a> and reach out to us.</p>
 	                </div>
@@ -128,16 +161,35 @@
         </div>
     </section>
 
-    <!-- Contact Section -->
-    <section id="codeofconduct">
+    <!-- Code of Conduct Section -->
+    <section class="success" id="codeofconduct">
         <div class="container">
             <div class="row">
                 <div class="col-lg-12 text-center">
                     <h2>Code of Conduct</h2>
-                    <hr class="star-primary">
+                    <hr class="star-light">
 					<div class="col-lg-8 col-lg-offset-2 text-center">
-	                    <p>FinagleCon is intended for professional networking and collaboration within the Finagle community. Attendees are expected to behave according to professional standards and in accordance with their employer's policies on appropriate workplace behavior. Our conference is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, or religion (or lack thereof). We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks, workshops, parties, Twitter and other online media. Conference participants violating these rules may be sanctioned or expelled from the conference without a refund at the discretion of the conference organizers. Participants asked to stop any harassing behavior are expected to comply immediately. Please bring any concerns to to the immediate attention of the FinagleCon event staff, or contact <a href="mailto:tbrown@twitter.com">Travis Brown</a>, FinagleCon Program Chair.</p>
+	                    <p>FinagleCon is intended for professional networking and collaboration within the Finagle community. Attendees are expected to behave according to professional standards and in accordance with their employer's policies on appropriate workplace behavior. Our conference is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, or religion (or lack thereof). We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks, workshops, parties, Twitter and other online media. Conference participants violating these rules may be sanctioned or expelled from the conference without a refund at the discretion of the conference organizers. Participants asked to stop any harassing behavior are expected to comply immediately. Please bring any concerns to to the <a href="mailto:finaglecon@twitter.com">immediate attention</a> of the FinagleCon event staff.</p>
 	                </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+   <!-- About Finagle Section -->
+    <section id="finagle">
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-12 text-center">
+                    <h2>About Finagle</h2>
+                    <hr class="star-primary">
+                    <div class="col-lg-8 col-lg-offset-2 text-center">
+                        <p>Want to learn more about Finagle? Visit the <a href="https://finagle.github.io/blog/">Finagle blog</a>,
+                            check out the <a href="https://github.com/twitter/finagle">project source</a>,
+                            follow <a href="https://twitter.com/finagle">@finagle</a> on Twitter, or join
+                            the <a href="https://groups.google.com/forum/#!forum/finaglers">Finaglers</a> mailing list!
+                        </p>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
@caniszczyk, I've added three things in this PR:
- A section with more info about Scala by the Bay and a link to the SbtB registration.
- A section on general Finagle info and links (it seemed like a shame that we weren't linking to this stuff anywhere).
- Google Analytics tracking.

Rendered version [here](https://travisbrown.github.io/finaglecon/).
